### PR TITLE
Remove private repo references from public spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The bot reviews specification repositories and proposes **tiny, high-leverage pu
 | Repo | Description |
 |---|---|
 | [tiny-pr-bot](https://github.com/ripper234/tiny-pr-bot) | This repo — the bot improves itself |
-| [know-thyself](https://github.com/ripper234/know-thyself) | Daily writing game aimed at self-knowledge |
+
+Additional repos can be configured by the operator via `config/clawbot.config.json`.
 
 ## Core Idea
 

--- a/config/clawbot.config.json
+++ b/config/clawbot.config.json
@@ -1,7 +1,6 @@
 {
   "target_repos": [
-    "ripper234/tiny-pr-bot",
-    "ripper234/know-thyself"
+    "ripper234/tiny-pr-bot"
   ],
   "timezone": "Asia/Jerusalem",
   "max_daily_cost_usd": 10,


### PR DESCRIPTION
Private monitored repos shouldn't be exposed in the public spec.

- README: removed know-thyself row, added note that additional repos are configured locally
- config: removed private repo from default target_repos

The operator's local config and polling script retain the full repo list.

**Referenced Files:**
- [README.md](https://github.com/ripper234/tiny-pr-bot/blob/jarvis/hide-private-repos/README.md)
- [config/clawbot.config.json](https://github.com/ripper234/tiny-pr-bot/blob/jarvis/hide-private-repos/config/clawbot.config.json)

— Jarvis
