### PR TITLE
Add know-thyself to monitored repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The bot reviews specification repositories and proposes **tiny, high-leverage pu
 | Repo | Description |
 |---|---|
 | [tiny-pr-bot](https://github.com/ripper234/tiny-pr-bot) | This repo — the bot improves itself |
+| [know-thyself](https://github.com/ripper234/know-thyself) | Daily writing game for self-knowledge |
 
 Additional repos can be configured by the operator via `config/clawbot.config.json`.
 

--- a/config/clawbot.config.json
+++ b/config/clawbot.config.json
@@ -1,6 +1,7 @@
 {
   "target_repos": [
-    "ripper234/tiny-pr-bot"
+    "ripper234/tiny-pr-bot",
+    "ripper234/know-thyself"
   ],
   "timezone": "Asia/Jerusalem",
   "max_daily_cost_usd": 10,


### PR DESCRIPTION
## Summary

The bot already monitors `ripper234/know-thyself` via the polling script, but both the config file and the README Monitored Repos table only listed `tiny-pr-bot`. This updates both to reflect actual behavior.

## Changes

- `config/clawbot.config.json` — added `ripper234/know-thyself` to `target_repos`
- `README.md` — added know-thyself row to Monitored Repos table

## Referenced Files

- `config/clawbot.config.json`
- `README.md`
