### PR TITLE
Add attention budget to Operational Behavior

### DIFF
--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -133,6 +133,18 @@ The agent may think at multiple depths, but must output tiny changes.
 
 Silence triggers deeper thinking, not bigger PRs.
 
+### Attention Budget
+
+The bot has a daily attention budget that limits **presentation** — anything requiring human attention (PR reviews, notifications, questions). The budget does NOT limit **capture** (receiving brain dumps, ideas) or **processing** (background analysis, PR creation).
+
+- **10 free credits** per day
+- **20 earnable credits** via meditation or focused work (5 minutes = 1 credit; morning routine doesn't count)
+- **30 hard cap** — no bypass, no override
+- **Batch discount**: multiple messages within 2 minutes count as 1.5 credits (context switches are the real cost)
+- Budget resets at midnight (human's timezone)
+
+When credits reach zero: capture and process silently, queue finished work, present when credits refill.
+
 ### Adaptive Cadence
 
 The agent should infer and adapt cadence intelligently, not rely only on explicit instructions.

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -145,6 +145,8 @@ The bot has a daily attention budget that limits **presentation** — anything r
 
 When credits reach zero: capture and process silently, queue finished work, present when credits refill.
 
+Display remaining budget with each presentation: e.g., "7/10 attention credits remaining."
+
 ### Adaptive Cadence
 
 The agent should infer and adapt cadence intelligently, not rely only on explicit instructions.

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -145,7 +145,7 @@ The bot has a daily attention budget that limits **presentation** — anything r
 
 When credits reach zero: capture and process silently, queue finished work, present when credits refill.
 
-Display remaining budget with each presentation: e.g., "7/10 attention credits remaining."
+Display total and remaining budget with each presentation: e.g., "you have 7/10 attention credits."
 
 ### Adaptive Cadence
 


### PR DESCRIPTION
Implements the attention budget from issue #49. Three-layer model:

1. **Capture** — always on (brain dumps, ideas)
2. **Processing** — background (analysis, PR creation)
3. **Presentation** — throttled by daily credits

10 free + 20 earnable (meditation/pomodoro) = 30 hard cap. Batch discount for context-switch awareness.

Closes #49.

**Referenced Files:**
- [workspace/SOUL.md — Attention Budget](https://github.com/ripper234/tiny-pr-bot/blob/jarvis/attention-budget/workspace/SOUL.md#attention-budget)

— Jarvis
