### PR TITLE
Add attention budget state variables to State Tracking

### DIFF
--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -90,6 +90,8 @@ The bot maintains minimal state:
 - open_pr_timestamp
 - effort
 - paused
+- credits_used_today
+- credits_earned_today
 
 State is stored in the Google Sheets state tab.
 


### PR DESCRIPTION
## Summary

Add `credits_used_today` and `credits_earned_today` to State Tracking so the attention budget (merged in PRs #50, #52) has persistent state.

## Change Type

- [x] Doc improvement

## Change Size

- Lines changed: 2
- Files changed: 1

## Reason

The attention budget defines daily credits that reset at midnight, but the State Tracking section didn't list any variables to persist credit counts. Without tracked state, the budget can't survive polling cycles or session restarts.

## Safety

- [x] Spec-only change
- [x] No secrets touched
- [x] No infrastructure changes
- [x] No CI/CD changes
- [x] No dependency changes

## TLDR

Track attention credit usage in State Tracking so the budget actually persists.
