### PR TITLE
Add HOT.md and proposals/ to repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Weekly reports include a **cost vs PR approval rate histogram**.
 
 ```
 workspace/
+  HOT.md
   SOUL.md
   AGENTS.md
   USER.md
@@ -92,6 +93,8 @@ workspace/
 
 config/
   clawbot.config.json
+
+proposals/
 ```
 
 ## Status


### PR DESCRIPTION
# Add HOT.md and proposals/ to repository structure

The documented repository structure in README.md was missing two existing paths:

- **`workspace/HOT.md`** — the most frequently read file (checked before every reply per AGENTS.md), yet undocumented
- **`proposals/`** — contains the tiered-memory proposal and future design documents

## Change Type
- [x] Doc improvement

## Change Size
- Lines changed: 3
- Files changed: 1

## Reason
HOT.md is the highest-priority file in the system — read before every reply. Not listing it in the structure is a real documentation gap that could confuse anyone reading the repo for the first time.

## TLDR
Add missing HOT.md and proposals/ to README repository structure.
