### PR TITLE
Clarify that only non-draft review PRs block generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The bot reviews specification repositories and proposes **tiny, high-leverage pu
 
 | Repo | Description |
 |---|---|
-| [tiny-pr-bot](https://github.com/ripper234/tiny-pr-bot) | This repo — the bot improves itself |
+| [tiny-pr-bot](https://github.com/ripper234/tiny-pr-bot) | This repo, currently the only configured target |
 
-Additional repos can be configured by the operator via `config/clawbot.config.json`.
+Additional repos can be added by the operator via `config/clawbot.config.json`.
 
 ## Core Idea
 

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -10,7 +10,7 @@ The bot maintains a continuous loop with two layers:
 
 A cron-scheduled script periodically checks:
 
-1. Is there an open PR awaiting review? → Do nothing.
+1. Is there an open non-draft PR awaiting review? → Do nothing.
 2. Is the bot currently generating a PR? → Do nothing.
 3. Otherwise → Trigger the generation layer.
 
@@ -34,7 +34,7 @@ Allow up to 60 minutes for generation to ensure quality over speed.
 
 For each target repository, exactly one of the following must be true:
 
-- A PR is submitted and awaiting review
+- A non-draft PR is submitted and awaiting review
 - A PR is being generated right now
 - The bot is in idle state (no useful PR to propose)
 


### PR DESCRIPTION
## Summary
Clarified that only non-draft review PRs block the loop, so draft PRs can coexist without freezing generation.

## Change Type
- [ ] Doc improvement
- [x] Refactor (move / rename / simplify)
- [ ] Research support
- [ ] TODO improvement
- [x] Other small improvement

## Change Size
Expected limits:
- Lines changed: ≤ 2
- Files changed: ≤ 1 preferred
- Absolute maximum: 3 files

## Reason
This removes a real contradiction between AGENTS and SOUL. SOUL allows multiple draft PRs, but AGENTS previously implied any open PR should block the loop.

## Decision Load
Low. This is a spec consistency fix.

## Safety
- [x] Spec-only change
- [x] No secrets touched
- [x] No infrastructure changes
- [x] No CI/CD changes
- [x] No dependency changes

## TLDR
Only non-draft review PRs should block new generation work.

## Referenced Files
- [workspace/SOUL.md](https://github.com/ripper234/tiny-pr-bot/blob/main/workspace/SOUL.md#draft-prs)
